### PR TITLE
Issue #704 Fixed

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -341,7 +341,7 @@ img {
   left: 33.5%;
   transform: translate(-50%, -50%);
   padding: 0;
-  margin: 158px -65px 0px;
+  margin: 12rem -4rem 0px;
   display: flex;
 
 }


### PR DESCRIPTION
# Description

There was no gap between get started text and social icons when being hovered ,and that was looking  ugly .

So had made some changes in the CSS of social icons for making some gap in between .

## Fixes #704 


## Screenshots


#### BEFORE CORRECTION
![Screenshot 2023-07-31 160358](https://github.com/aniketsinha2002/DataScienceWebsite.github.io/assets/105539123/258e916a-0073-4dc4-849b-16a91a90513e)

#### AFTER CORRECTION
![Screenshot 2023-08-02 113951](https://github.com/aniketsinha2002/DataScienceWebsite.github.io/assets/105539123/3141b9fe-953e-4c5f-a9ba-70d2f69f49ba)




Thank you !