### PR TITLE
Fixed Courses Hero Section

### DIFF
--- a/courses.css
+++ b/courses.css
@@ -417,7 +417,7 @@ header {
   position: relative;
   top: 5rem;
   overflow: hidden;
-  height: 70vh;
+  
   margin-bottom: 5rem;
 }
 


### PR DESCRIPTION
Fixes #714 

# Description

Fixed the issue of the presence of the hero section on the courses page just after the navbar. The hero section of the courses page is not visible on the viewer's screen instead a black screen is visible, and after a scroll hero section is visible.


## Fixes #(#714)



## Screenshots

[
![fixed_hero](https://github.com/aniketsinha2002/DataScienceWebsite.github.io/assets/84717393/7adb7b95-3428-435d-828d-f76385ed30fb)
](url)

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [ ] Code follows the established coding style guidelines
- [ ] All tests are passing
