### PR TITLE
Scroll Animation offset now causes accurate jump

### DIFF
--- a/smoothscroll.js
+++ b/smoothscroll.js
@@ -1,6 +1,9 @@
 $('nav ul li a').click(function(){
-    var thisSection=$(this).attr('href');
-     $('html, body').stop().animate({
-    scrollTop:$(thisSection).offset().top-140
-    },600,'easeOutCirc');
+    var thisSection = $(this).attr('href');
+    var headerHeight = $('.fixed-header').outerHeight(); // Replace '.fixed-header' with selector of your fixed header.
+    var scrollOffset = headerHeight || 0; // Use the header height as the offset, or set it to 0 if there's no fixed header.
+
+    $('html, body').stop().animate({
+        scrollTop: $(thisSection).offset().top - scrollOffset
+    }, 600, 'easeOutCirc');
 });


### PR DESCRIPTION
# Description

The current scroll animation in the provided code snippet has an offset of -140 pixels from the top of the target section. While the intention behind adding the offset might be to account for a fixed header, it introduces an issue where the scrolling behavior becomes inaccurate under certain circumstances.
Proposed Solution:
Adjust the scroll animation offset in the JavaScript code to ensure accurate scrolling and alignment with the fixed header. Ideally, the offset should be equal to the height of the fixed header (if any) to maintain consistency across different devices and screen sizes.

## Fixes #722 

Replace `issue_no` with the issue number which is fixed in this PR


<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing
